### PR TITLE
Use `get_job_id()` instead of `get_job_status()` to avoid errors when deploying to KDA.

### DIFF
--- a/pyflink-examples/GettingStarted/getting-started.py
+++ b/pyflink-examples/GettingStarted/getting-started.py
@@ -151,8 +151,8 @@ def main():
     if is_local:
         table_result.wait()
     else:
-        # get job status through TableResult
-        print(table_result.get_job_client().get_job_status())
+        # get job id through TableResult
+        print(table_result.get_job_client().get_job_id())
 
 
 if __name__ == "__main__":

--- a/pyflink-examples/SlidingWindows/sliding-windows.py
+++ b/pyflink-examples/SlidingWindows/sliding-windows.py
@@ -148,8 +148,8 @@ def main():
     if is_local:
         table_result1.wait()
     else:
-        # get job status through TableResult
-        print(table_result1.get_job_client().get_job_status())
+        # get job id through TableResult
+        print(table_result1.get_job_client().get_job_id())
 
 
 

--- a/pyflink-examples/StreamingFileSink/streaming-file-sink.py
+++ b/pyflink-examples/StreamingFileSink/streaming-file-sink.py
@@ -173,8 +173,8 @@ def main():
     if is_local:
         table_result.wait()
     else:
-        # get job status through TableResult
-        print(table_result.get_job_client().get_job_status())
+        # get job id through TableResult
+        print(table_result.get_job_client().get_job_id())
 
 
 if __name__ == "__main__":

--- a/pyflink-examples/TumblingWindows/tumbling-windows.py
+++ b/pyflink-examples/TumblingWindows/tumbling-windows.py
@@ -145,8 +145,8 @@ def main():
     if is_local:
         table_result.wait()
     else:
-        # get job status through TableResult
-        print(table_result.get_job_client().get_job_status())
+        # get job id through TableResult
+        print(table_result.get_job_client().get_job_id())
 
 
 

--- a/pyflink-examples/UDF/udf.py
+++ b/pyflink-examples/UDF/udf.py
@@ -149,8 +149,8 @@ def main():
     if is_local:
         table_result.wait()
     else:
-        # get job status through TableResult
-        print(table_result.get_job_client().get_job_status())
+        # get job id through TableResult
+        print(table_result.get_job_client().get_job_id())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`get_job_status()` would cause the following errors when deployed to KDA:

```
py4j.protocol.Py4JJavaError: An error occurred while calling o156.getJobStatus.
: org.apache.flink.util.FlinkRuntimeException: The Job Status cannot be requested when in Web Submission.
	at org.apache.flink.client.deployment.application.WebSubmissionJobClient.getJobStatus(WebSubmissionJobClient.java:58)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.flink.api.python.shaded.py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
	at org.apache.flink.api.python.shaded.py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
	at org.apache.flink.api.python.shaded.py4j.Gateway.invoke(Gateway.java:282)
	at org.apache.flink.api.python.shaded.py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	at org.apache.flink.api.python.shaded.py4j.commands.CallCommand.execute(CallCommand.java:79)
	at org.apache.flink.api.python.shaded.py4j.GatewayConnection.run(GatewayConnection.java:238)
	at java.base/java.lang.Thread.run(Thread.java:829)
```